### PR TITLE
fix GENERATE_SKIP_SPEC_DOWNLOAD: true

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           go-version-file: pkg/generate/go.mod
           cache-dependency-path: pkg/generate/go.sum
       - run: go generate ./...
-      - run: git diff "*.html"
-      - run: git diff --exit-code "*.go"
         env:
           GENERATE_SKIP_SPEC_DOWNLOAD: true
+      - run: git diff "*.html"
+      - run: git diff --exit-code "*.go"


### PR DESCRIPTION
fix the workflow to add the env variable to the `go generate` command